### PR TITLE
Feat: History/Order Part 2

### DIFF
--- a/admin/src/main/java/com/hika/admin/adapter/OrderAdminAdapter.kt
+++ b/admin/src/main/java/com/hika/admin/adapter/OrderAdminAdapter.kt
@@ -1,5 +1,6 @@
 package com.hika.admin.adapter
 
+import android.app.Dialog
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -7,16 +8,19 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.hika.common.base.BaseDiffUtil
 import com.hika.common.base.BaseRecyclerViewAdapter
 import com.hika.common.common.gone
+import com.hika.common.common.toOrderHistoryFormat
 import com.hika.common.common.toRupiahFormat
+import com.hika.common.common.visible
 import com.hika.common.databinding.ItemHistoryBinding
 import com.hika.common.databinding.ItemProductOrderBinding
 import com.hika.common.util.OrderStatus
+import com.hika.common.widget.buildOrderHistoryConfirmationDialog
 import com.hika.data.model.History
 import com.hika.data.model.PerfumeHistory
 
 class OrderAdminAdapter(
     private val onPositiveButtonClick: (String, String) -> Unit = { _, _ -> },
-    private val onNegativeButtonClick: (String) -> Unit = { }
+    private val onNegativeButtonClick: Dialog.(String, String) -> Unit = { _, _ -> }
 ): BaseRecyclerViewAdapter<ItemHistoryBinding, History>() {
 
     override fun inflateViewBinding(parent: ViewGroup): ItemHistoryBinding {
@@ -28,7 +32,7 @@ class OrderAdminAdapter(
 
     override fun ItemHistoryBinding.binds(data: History) {
         tvBuyer.text = "${data.buyerName}\'s Order"
-        tvDate.text = data.date.toString()
+        tvDate.text = data.date.toOrderHistoryFormat()
 
         val productOrderAdapter = ProductOrderAdminAdapter()
         rvOrder.apply {
@@ -79,7 +83,18 @@ class OrderAdminAdapter(
         }
 
         btnNegative.setOnClickListener {
-            onNegativeButtonClick(data.id)
+            root.context.buildOrderHistoryConfirmationDialog(
+                title = "Cancel Order",
+                message = "Please provide a reason for rejecting this order",
+                showTextField = true,
+            ) {
+                this.onNegativeButtonClick(data.id, it)
+            }.show()
+        }
+
+        if (data.reason != null) {
+            tvAdditionalInformation.text = "Reason: ${data.reason}"
+            tvAdditionalInformation.visible()
         }
     }
 

--- a/admin/src/main/java/com/hika/admin/features/order/OrderAdminFragment.kt
+++ b/admin/src/main/java/com/hika/admin/features/order/OrderAdminFragment.kt
@@ -16,7 +16,7 @@ class OrderAdminFragment : BaseFragment<FragmentOrderAdminBinding>() {
     private val orderAdminAdapter by lazy {
         OrderAdminAdapter(
             onPositiveButtonClick = { orderId, status -> viewModel.confirmOrder(orderId, status) },
-            onNegativeButtonClick = { orderId -> viewModel.rejectOrder(orderId) }
+            onNegativeButtonClick = { orderId, reason -> viewModel.rejectOrder(orderId, reason) }
         )
     }
 

--- a/admin/src/main/java/com/hika/admin/features/order/OrderAdminViewModel.kt
+++ b/admin/src/main/java/com/hika/admin/features/order/OrderAdminViewModel.kt
@@ -35,7 +35,7 @@ class OrderAdminViewModel(
             else -> OrderStatus.REJECTED_BY_ADMIN
         }
         viewModelScope.launch {
-            orderRepository.updateHistoryStatus(orderId, updatedOrderStatus.name).onSuccess {
+            orderRepository.updateHistoryStatus(orderId, updatedOrderStatus.name, null).onSuccess {
                 getOrders()
             }.onFailure {
                 _state.value = _state.value.copy(isError = true, errorMessage = it.message.orEmpty())
@@ -44,10 +44,10 @@ class OrderAdminViewModel(
         }
     }
 
-    fun rejectOrder(orderId: String) {
+    fun rejectOrder(orderId: String, reason: String) {
         _state.value = _state.value.copy(isLoading = true)
         viewModelScope.launch {
-            orderRepository.updateHistoryStatus(orderId, OrderStatus.REJECTED_BY_ADMIN.name).onSuccess {
+            orderRepository.updateHistoryStatus(orderId, OrderStatus.REJECTED_BY_ADMIN.name, reason).onSuccess {
                 getOrders()
             }.onFailure {
                 _state.value = _state.value.copy(isError = true, errorMessage = it.message.orEmpty())

--- a/app/src/main/java/com/hika/myscent/adapter/HistoryAdapter.kt
+++ b/app/src/main/java/com/hika/myscent/adapter/HistoryAdapter.kt
@@ -1,21 +1,25 @@
 package com.hika.myscent.adapter
 
+import android.app.Dialog
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.hika.common.base.BaseRecyclerViewAdapter
 import com.hika.common.common.gone
+import com.hika.common.common.toOrderHistoryFormat
 import com.hika.common.common.toRupiahFormat
+import com.hika.common.common.visible
 import com.hika.common.databinding.ItemHistoryBinding
 import com.hika.common.databinding.ItemProductOrderBinding
 import com.hika.common.util.OrderStatus
+import com.hika.common.widget.buildOrderHistoryConfirmationDialog
 import com.hika.data.model.History
 import com.hika.data.model.PerfumeHistory
 
 class HistoryAdapter(
     private val onPositiveButtonClick: (String, String) -> Unit = { _, _ -> },
-    private val onNegativeButtonClick: (String) -> Unit = { }
+    private val onNegativeButtonClick: Dialog.(String, String) -> Unit = {_, _ ->  }
 ): BaseRecyclerViewAdapter<ItemHistoryBinding, History>() {
     override fun inflateViewBinding(parent: ViewGroup): ItemHistoryBinding {
         return ItemHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -26,7 +30,7 @@ class HistoryAdapter(
 
     override fun ItemHistoryBinding.binds(data: History) {
         tvBuyer.text = "Your Order"
-        tvDate.text = data.date.toString()
+        tvDate.text = data.date.toOrderHistoryFormat()
 
         val productOrderAdapter = ProductHistoryAdapter()
         rvOrder.apply {
@@ -39,7 +43,7 @@ class HistoryAdapter(
         tvShippingAddressValue.text = data.shippingAddress
 
         btnPositive.text = "Confirm"
-        btnNegative.text = "Reject"
+        btnNegative.text = "Cancel"
 
         when(data.status) {
             OrderStatus.WAIT_FOR_ADMIN_CONFIRMATION.name -> {
@@ -78,7 +82,18 @@ class HistoryAdapter(
         }
 
         btnNegative.setOnClickListener {
-            onNegativeButtonClick(data.id)
+            root.context.buildOrderHistoryConfirmationDialog(
+                title = "Cancel Order",
+                message = "Please enter the reason for cancellation",
+                showTextField = true,
+            ) {
+                this.onNegativeButtonClick(data.id, it)
+            }.show()
+        }
+
+        if (data.reason != null) {
+            tvAdditionalInformation.text = "Reason: ${data.reason}"
+            tvAdditionalInformation.visible()
         }
     }
 }

--- a/app/src/main/java/com/hika/myscent/features/history/HistoryActivity.kt
+++ b/app/src/main/java/com/hika/myscent/features/history/HistoryActivity.kt
@@ -20,9 +20,9 @@ class HistoryActivity : BaseActivity<ActivityHistoryBinding>() {
             intent.putExtra(HistoryPaymentActivity.HISTORY_ID, historyId)
             startActivity(intent)
         },
-        onNegativeButtonClick = { historyId ->
-            // Do something
-            viewModel.rejectHistory(historyId)
+        onNegativeButtonClick = { historyId, reason ->
+            viewModel.rejectHistory(historyId, reason)
+            dismiss()
         }
     )}
 

--- a/app/src/main/java/com/hika/myscent/features/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/hika/myscent/features/history/HistoryViewModel.kt
@@ -27,10 +27,10 @@ class HistoryViewModel(
         }
     }
 
-    fun rejectHistory(historyId: String) {
+    fun rejectHistory(historyId: String, reason: String) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true)
-            historyRepository.updateHistoryStatus(historyId, OrderStatus.REJECTED_BY_USER.name).onSuccess {
+            historyRepository.updateHistoryStatus(historyId, OrderStatus.REJECTED_BY_USER.name, reason).onSuccess {
                 getHistories()
             }.onFailure {
                 _state.value = _state.value.copy(isError = true, errorMessage = it.message.orEmpty())

--- a/app/src/main/java/com/hika/myscent/features/history/payment/HistoryPaymentActivity.kt
+++ b/app/src/main/java/com/hika/myscent/features/history/payment/HistoryPaymentActivity.kt
@@ -3,6 +3,7 @@ package com.hika.myscent.features.history.payment
 import androidx.lifecycle.lifecycleScope
 import com.hika.common.base.BaseActivity
 import com.hika.common.common.toRupiahFormat
+import com.hika.common.widget.buildOrderHistoryConfirmationDialog
 import com.hika.myscent.databinding.ActivityHistoryPaymentBinding
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -32,10 +33,15 @@ class HistoryPaymentActivity : BaseActivity<ActivityHistoryPaymentBinding>() {
                     tvDeliveryPointer.text = it.successData?.shippingAddress
                     tvTotalPrice.text = it.successData?.totalPrice?.toRupiahFormat()
                     btnConfirmPayment.setOnClickListener {
-                        viewModel.confirmPayment(historyId) {
-                            showSuccessSnackBar("Payment confirmation sent. Please wait for admin approval")
-                            finish()
-                        }
+                        buildOrderHistoryConfirmationDialog(
+                            "Payment Confirmation",
+                            "Before you confirm, please make sure you have transferred the payment to the account number"
+                        ) {
+                            viewModel.confirmPayment(historyId) {
+                                finish()
+                                showSuccessSnackBar("Payment confirmation sent. Please wait for admin approval")
+                            }
+                        }.show()
                     }
                 }
             }

--- a/app/src/main/java/com/hika/myscent/features/history/payment/HistoryPaymentViewModel.kt
+++ b/app/src/main/java/com/hika/myscent/features/history/payment/HistoryPaymentViewModel.kt
@@ -29,7 +29,7 @@ class HistoryPaymentViewModel(
     fun confirmPayment(historyId: String, onSuccess: () -> Unit) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true)
-            historyRepository.updateHistoryStatus(historyId, OrderStatus.WAIT_FOR_ADMIN_PAYMENT_APPROVAL.name).onSuccess {
+            historyRepository.updateHistoryStatus(historyId, OrderStatus.WAIT_FOR_ADMIN_PAYMENT_APPROVAL.name, null).onSuccess {
                 _state.value = _state.value.copy(isLoading = false, isSuccess = true)
                 onSuccess()
             }.onFailure {

--- a/common/src/main/java/com/hika/common/common/Converter.kt
+++ b/common/src/main/java/com/hika/common/common/Converter.kt
@@ -1,5 +1,9 @@
 package com.hika.common.common
 
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
 fun Int.toRupiahFormat(): String {
     val rupiah = StringBuilder(toString())
     var i = rupiah.length - 3
@@ -8,4 +12,14 @@ fun Int.toRupiahFormat(): String {
         i -= 3
     }
     return "Rp$rupiah"
+}
+
+fun Date.toOrderHistoryFormat(): String {
+    val date = this.toString()
+    val inputFormat = SimpleDateFormat("EEE MMM dd HH:mm:ss 'GMT'Z yyyy", Locale.ENGLISH)
+    val outputFormat = SimpleDateFormat("MMM dd yyyy HH:mm:ss", Locale.ENGLISH)
+
+    val result = inputFormat.parse(date) ?: this
+
+    return outputFormat.format(result)
 }

--- a/common/src/main/java/com/hika/common/widget/CancelRejectionDialog.kt
+++ b/common/src/main/java/com/hika/common/widget/CancelRejectionDialog.kt
@@ -2,20 +2,31 @@ package com.hika.common.widget
 
 import android.app.Dialog
 import android.content.Context
-import com.hika.common.databinding.DialogCancelRejectionOrderBinding
+import android.widget.LinearLayout
+import com.hika.common.common.gone
+import com.hika.common.databinding.DialogOrderHistoryConfirmationBinding
 
-fun Context.buildCancelRejectionOrderDialog(
-    title: String,
-    message: String,
-    onButtonPressed: Dialog.(String) -> Unit
+fun Context.buildOrderHistoryConfirmationDialog(
+    title: String = "",
+    message: String = "",
+    showTextField: Boolean = false,
+    onButtonPressed: Dialog.(String) -> Unit = {}
 ) = Dialog(this).apply {
-    val binding = DialogCancelRejectionOrderBinding.inflate(layoutInflater)
+    val binding = DialogOrderHistoryConfirmationBinding.inflate(layoutInflater)
     setContentView(binding.root)
+    this.window?.setLayout(
+        (resources.configuration.screenWidthDp * resources.displayMetrics.density * 0.9).toInt(),
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+    )
 
     binding.tvTitle.text = title
     binding.tvMessage.text = message
 
     binding.btnConfirm.setOnClickListener {
         onButtonPressed(binding.edtReason.text.toString())
+    }
+
+    binding.tilReason.apply {
+        if (showTextField) show() else gone()
     }
 }

--- a/common/src/main/res/layout/dialog_order_history_confirmation.xml
+++ b/common/src/main/res/layout/dialog_order_history_confirmation.xml
@@ -10,7 +10,7 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textSize="18sp"
+        android:textSize="16sp"
         android:textStyle="bold"
         android:fontFamily="@font/poppins_semibold"
         android:gravity="center"
@@ -22,10 +22,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:textSize="14sp"
+        android:textSize="12sp"
         android:fontFamily="@font/poppins"
         android:gravity="center"
-        android:textColor="@color/primary_700"
+        android:textColor="@color/neutral_900"
         app:layout_constraintTop_toBottomOf="@id/tv_title" />
 
     <com.google.android.material.textfield.TextInputLayout

--- a/common/src/main/res/layout/dialog_payment_order.xml
+++ b/common/src/main/res/layout/dialog_payment_order.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-</androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/src/main/res/layout/item_history.xml
+++ b/common/src/main/res/layout/item_history.xml
@@ -47,13 +47,25 @@
             app:layout_constraintTop_toBottomOf="@id/tv_date"
             tools:text="Status: Paid"/>
 
+        <TextView
+            android:id="@+id/tv_additional_information"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="@color/neutral_700"
+            android:fontFamily="@font/poppins"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_status"
+            tools:text="Additional Information: "/>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_order"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:nestedScrollingEnabled="false"
-            app:layout_constraintTop_toBottomOf="@id/tv_status"
+            app:layout_constraintTop_toBottomOf="@id/tv_additional_information"
             tools:itemCount="5"
             tools:listitem="@layout/item_product_order"/>
 
@@ -124,18 +136,6 @@
                 app:cornerRadius="8dp"/>
 
         </LinearLayout>
-
-        <TextView
-            android:id="@+id/tv_additional_information"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:textSize="14sp"
-            android:textColor="@color/neutral_700"
-            android:fontFamily="@font/poppins"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/ll_buttons"
-            tools:text="Additional Information: "/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/data/src/main/java/com/hika/data/data/repository/history/HistoryRepository.kt
+++ b/data/src/main/java/com/hika/data/data/repository/history/HistoryRepository.kt
@@ -7,5 +7,5 @@ interface HistoryRepository {
     suspend fun postHistory(body: HistoryBody): Result<Unit>
     suspend fun getHistories(): Result<List<History>>
     suspend fun getHistoryById(historyId: String): Result<History>
-    suspend fun updateHistoryStatus(historyId: String, updatedOrderStatus: String): Result<Unit>
+    suspend fun updateHistoryStatus(historyId: String, updatedOrderStatus: String, reason: String?): Result<Unit>
 }

--- a/data/src/main/java/com/hika/data/data/repository/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/hika/data/data/repository/history/HistoryRepositoryImpl.kt
@@ -101,12 +101,21 @@ class HistoryRepositoryImpl(
 
     override suspend fun updateHistoryStatus(
         historyId: String,
-        updatedOrderStatus: String
+        updatedOrderStatus: String,
+        reason: String?
     ): Result<Unit> {
         return try {
             firestore.collection(HISTORIES)
                 .document(historyId)
-                .update("status", updatedOrderStatus)
+                .update(
+                    if (reason == null)
+                        mapOf("status" to updatedOrderStatus)
+                    else
+                        mapOf(
+                            "status" to updatedOrderStatus,
+                            "reason" to reason
+                        )
+                )
                 .await()
 
             Result.success(Unit)

--- a/data/src/main/java/com/hika/data/data/util/Mapper.kt
+++ b/data/src/main/java/com/hika/data/data/util/Mapper.kt
@@ -44,11 +44,12 @@ fun DocumentSnapshot.toHistory(
     perfumeHistories: List<PerfumeHistory> = emptyList()
 ) = History(
     id,
-    getTimestamp("date") ?: Timestamp.now(),
+    getTimestamp("date")?.toDate() ?: Timestamp.now().toDate(),
     getField<Int>("totalPrice") ?: 0,
     getString("status").orEmpty(),
     getString("buyerName").orEmpty(),
     getString("shippingAddress").orEmpty(),
+    getString("reason"),
     get("productToAmount") as? HashMap<String, Long> ?: hashMapOf(),
     perfumeHistories
 )

--- a/data/src/main/java/com/hika/data/model/History.kt
+++ b/data/src/main/java/com/hika/data/model/History.kt
@@ -1,14 +1,16 @@
 package com.hika.data.model
 
 import com.google.firebase.Timestamp
+import java.util.Date
 
 data class History(
     val id: String = "",
-    val date: Timestamp = Timestamp.now(),
+    val date: Date = Date(),
     val totalPrice: Int = 0,
     val status: String = "",
     val buyerName: String = "",
     val shippingAddress: String = "",
+    val reason: String? = null,
     val productToAmount: HashMap<String, Long> = hashMapOf(),
     val products: List<PerfumeHistory> = emptyList(),
 )


### PR DESCRIPTION
2nd part of #29 

This pull request is relate with following issue: #30 

# Summary
I've created the history of order for user and admin

# Changes
- Designed common items for history's item list
- Added confirmation dialog for payment confirmation and order rejection/cancelation
- Fetched histories from firestore and separated into 2 different use cases depend on user's roles (admin and user)
- Updated status to firestore
- Revised payment flows from user order -> admin approval -> user payment -> admin payment approval -> shipping
- Adding a unique code to distinguish one order from another

# Review
I've tested all the flows and it works how it supposed to be

# Issue
Close #30 