### PR TITLE
Shows Only Available Perfumes

### DIFF
--- a/data/src/main/java/com/hika/data/data/repository/perfume/PerfumeRepositoryImpl.kt
+++ b/data/src/main/java/com/hika/data/data/repository/perfume/PerfumeRepositoryImpl.kt
@@ -68,7 +68,7 @@ return try {
         return try {
             coroutineScope {
                 val perfumesDeferred = async(Dispatchers.IO) {
-                    firestore.collection(PERFUMES).get().await().documents.map {
+                    firestore.collection(PERFUMES).whereEqualTo("isAvailable", true).get().await().documents.map {
                         it.toPerfume()
                     }
                 }


### PR DESCRIPTION
This pull request is relate with following issue: #34 

# Summary
I've refactored the queries from firestore

# Changes
- Added `whereEqualTo` function to get items that `isAvailable` variable is `true`

# Review
I've tested all the flows and it works how it supposed to be

# Issue
Close #33 